### PR TITLE
nft: Introduce Lookup{Table,Chain,Rule} helpers

### DIFF
--- a/nft/chain.go
+++ b/nft/chain.go
@@ -90,3 +90,29 @@ func (c *Config) FlushChain(chain *schema.Chain) {
 	nftable := schema.Nftable{Flush: &schema.Objects{Chain: chain}}
 	c.Nftables = append(c.Nftables, nftable)
 }
+
+func (c *Config) LookupChain(toFind *schema.Chain) *schema.Chain {
+	for _, nftable := range c.Nftables {
+		if chain := nftable.Chain; chain != nil {
+			match := chain.Table == toFind.Table && chain.Family == toFind.Family && chain.Name == toFind.Name
+			if match {
+				if t := toFind.Type; t != "" {
+					match = match && chain.Type == t
+				}
+				if h := toFind.Hook; h != "" {
+					match = match && chain.Hook == h
+				}
+				if p := toFind.Prio; p != nil {
+					match = match && chain.Prio != nil && *chain.Prio == *p
+				}
+				if p := toFind.Policy; p != "" {
+					match = match && chain.Policy == p
+				}
+				if match {
+					return chain
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/nft/table.go
+++ b/nft/table.go
@@ -63,3 +63,14 @@ func (c *Config) FlushTable(table *schema.Table) {
 	nftable := schema.Nftable{Flush: &schema.Objects{Table: table}}
 	c.Nftables = append(c.Nftables, nftable)
 }
+
+func (c *Config) LookupTable(toFind *schema.Table) *schema.Table {
+	for _, nftable := range c.Nftables {
+		if t := nftable.Table; t != nil {
+			if t.Name == toFind.Name && t.Family == toFind.Family {
+				return t
+			}
+		}
+	}
+	return nil
+}

--- a/nft/table_test.go
+++ b/nft/table_test.go
@@ -35,6 +35,7 @@ const tableName = "test-table"
 
 func TestTable(t *testing.T) {
 	testTableActions(t)
+	testTableLookup(t)
 }
 
 func testTableActions(t *testing.T) {
@@ -75,5 +76,25 @@ func testTableAction(t *testing.T, actionName nft.TableAction, actionFunc tableA
 			expected = []byte(fmt.Sprintf(`{"nftables":[{%q:{"table":{"family":%q,"name":%q}}}]}`, actionName, family, tableName))
 		}
 		assert.Equal(t, string(expected), string(serializedConfig))
+	})
+}
+
+func testTableLookup(t *testing.T) {
+	config := nft.NewConfig()
+	config.AddTable(nft.NewTable("table-ip", nft.FamilyIP))
+	config.AddTable(nft.NewTable("table-ip", nft.FamilyIP6))
+	table_br := nft.NewTable("table-br", nft.FamilyBridge)
+	config.AddTable(table_br)
+
+	config.AddChain(nft.NewRegularChain(table_br, "chain-br"))
+
+	t.Run("Lookup an existing table", func(t *testing.T) {
+		table := config.LookupTable(table_br)
+		assert.Equal(t, *table_br, *table)
+	})
+
+	t.Run("Lookup a missing table", func(t *testing.T) {
+		table := config.LookupTable(nft.NewTable("table-na", nft.FamilyBridge))
+		assert.Nil(t, table)
 	})
 }


### PR DESCRIPTION
Lookup helpers are useful after reading the existing configuration from
the system and examining if specific items are included in it.

The table and chain lookups return a single object.
The rule lookup returns a list of rules (as duplication may exist).