### PR TITLE
automation, tests: Set fixed container image tag

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -8,7 +8,7 @@ PROJECT_PATH="$(dirname $EXEC_PATH)"
 CONTAINER_WORKSPACE="/workspace/go-nft"
 
 : "${CONTAINER_CMD:="docker"}"
-: "${CONTAINER_IMG:="golang:alpine"}"
+: "${CONTAINER_IMG:="golang:1.16.4-alpine3.13"}"
 
 : "${DISABLE_IPV6_IN_CONTAINER:=0}"
 


### PR DESCRIPTION
The integration tests have started failing after the golang:alpine image
got updated. In order to avoid such cases, this change is fixing
statically the image tag to golang:1.16.4-alpine3.13.