### PR TITLE
tests: Use testify require package instead of assert

### DIFF
--- a/nft/chain_test.go
+++ b/nft/chain_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/require"
 
 	"github.com/eddev/go-nft/nft"
 	"github.com/eddev/go-nft/nft/schema"

--- a/nft/config_test.go
+++ b/nft/config_test.go
@@ -23,11 +23,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/eddev/go-nft/nft/schema"
-
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/require"
 
 	"github.com/eddev/go-nft/nft"
+	"github.com/eddev/go-nft/nft/schema"
 )
 
 func TestDefineEmptyConfig(t *testing.T) {

--- a/nft/rule_test.go
+++ b/nft/rule_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/require"
 
 	"github.com/eddev/go-nft/nft"
 	"github.com/eddev/go-nft/nft/schema"

--- a/nft/table_test.go
+++ b/nft/table_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/require"
 
 	"github.com/eddev/go-nft/nft"
 	"github.com/eddev/go-nft/nft/schema"

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -22,10 +22,10 @@ package tests
 import (
 	"testing"
 
+	assert "github.com/stretchr/testify/require"
+
 	"github.com/eddev/go-nft/nft"
 	"github.com/eddev/go-nft/nft/schema"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig(t *testing.T) {

--- a/tests/example_test.go
+++ b/tests/example_test.go
@@ -23,10 +23,10 @@ import (
 	"sort"
 	"testing"
 
+	assert "github.com/stretchr/testify/require"
+
 	"github.com/eddev/go-nft/nft"
 	"github.com/eddev/go-nft/nft/schema"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNoMacSpoofingExample(t *testing.T) {


### PR DESCRIPTION
The testify assertion library provides two packages for assertions. One
that will notify on the failure but will continue with other assertions
in the same test (assert package) and another that will stop the test on
the first failure and will continue to the next test (require package).

This behavior is confusing, as many developers would expect `assert` to
mean "stop here if it fails".

Therefore, the following change aliases the `require` package with the
`assert` name.
In case there will be a need to assert and still continue on with the
test, it will be considered an exception and a proper alias will be
given for the original assert package.