### PR TITLE
exec, cgo: Add cgo binding to libnftables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,9 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16
+    
+    - name: Install nftable headers
+      run: sudo apt-get install libnftables-dev
 
     - name: Format Check
       run: ./automation/run-tests.sh --fmt

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.x] - yyyy-mm-dd
+ - Add support to link with libnftables using CGO
+   In order to use the lib backend, libnftables devel headers needs to be installed on the build machine.
+
 ## [0.1.1] - 2021-06-29
 ### Breaking Changes
  - Move the repo to the networkplumbing organization.

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -89,6 +89,8 @@ if [ -n "${OPT_ITEST}" ]; then
     run_container '
         apk add --no-cache nftables gcc musl-dev
         nft -j list ruleset
-        go test -v ./tests/...
+        go test -v --tags=exec ./tests/...
+        apk add --no-cache nftables-dev
+        go test -v ./tests/nftlib
     '
 fi

--- a/nft/lib/lib.go
+++ b/nft/lib/lib.go
@@ -1,0 +1,101 @@
+// +build cgo
+
+/*
+ * This file is part of the go-nft project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+package lib
+
+// #cgo CFLAGS: -g -Wall
+// #cgo LDFLAGS: -lnftables
+// #include <nftables/libnftables.h>
+// #include <stdlib.h>
+// #include <string.h>
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/networkplumbing/go-nft/nft"
+)
+
+const (
+	cmdList    = "list"
+	cmdRuleset = "ruleset"
+)
+
+// ReadConfig loads the nftables configuration from the system and
+// returns it as a nftables config structure.
+// The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
+func ReadConfig() (*nft.Config, error) {
+	stdout, err := libNftablesRunCmd(fmt.Sprintf("%s %s", cmdList, cmdRuleset))
+	if err != nil {
+		return nil, err
+	}
+
+	config := nft.NewConfig()
+	if err := config.FromJSON(stdout); err != nil {
+		return nil, fmt.Errorf("failed to list ruleset: %v", err)
+	}
+
+	return config, nil
+}
+
+// ApplyConfig applies the given nftables config on the system.
+// The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
+func ApplyConfig(c *nft.Config) error {
+	data, err := c.ToJSON()
+	if err != nil {
+		return err
+	}
+
+	if _, err = libNftablesRunCmd(string(data)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func libNftablesRunCmd(cmd string) ([]byte, error) {
+	nft := C.nft_ctx_new(C.NFT_CTX_DEFAULT)
+	defer C.nft_ctx_free(nft)
+
+	C.nft_ctx_output_set_flags(nft, C.NFT_CTX_OUTPUT_JSON)
+
+	buf := C.CString(cmd)
+	defer C.free(unsafe.Pointer(buf))
+
+	rc := C.nft_ctx_buffer_output(nft)
+	if rc != C.EXIT_SUCCESS {
+		return nil, fmt.Errorf("failed enabling output buffering (rc=%d)", rc)
+	}
+
+	rc = C.nft_ctx_buffer_error(nft)
+	if rc != C.EXIT_SUCCESS {
+		return nil, fmt.Errorf("failed enabling error buffering (rc=%d)", rc)
+	}
+
+	rc = C.nft_run_cmd_from_buffer(nft, buf)
+	if rc != C.EXIT_SUCCESS {
+		errMsg := C.nft_ctx_get_error_buffer(nft)
+		return nil, fmt.Errorf("failed running cmd (rc=%d): %s", rc, C.GoString(errMsg))
+	}
+
+	config := C.nft_ctx_get_output_buffer(nft)
+	configLen := C.int(C.strlen(config))
+	return C.GoBytes(unsafe.Pointer(config), configLen), nil
+}

--- a/tests/nftlib/nftlib_test.go
+++ b/tests/nftlib/nftlib_test.go
@@ -1,0 +1,48 @@
+// +build !exec
+
+/* This file is part of the go-nft project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+package main
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/networkplumbing/go-nft/nft"
+	nftlib "github.com/networkplumbing/go-nft/nft/lib"
+
+	"github.com/networkplumbing/go-nft/tests/testlib"
+)
+
+func TestNftlib(t *testing.T) {
+	testlib.RunTestWithFlushTable(t, func(t *testing.T) {
+		config := nft.NewConfig()
+		config.AddTable(nft.NewTable("mytable", nft.FamilyIP))
+
+		assert.NoError(t, nftlib.ApplyConfig(config))
+
+		newConfig, err := nftlib.ReadConfig()
+		assert.NoError(t, err)
+
+		assert.Len(t, newConfig.Nftables, 2, "Expecting the metainfo and an empty table entry")
+		assert.Equal(t, config.Nftables[0], newConfig.Nftables[1])
+		_, err = nftlib.ReadConfig()
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
By using libnftables directly, there is no need to exec a new process.
For the user perspective, it should look the same, as the details of how to
apply/read the nftables configuration is abstracted away.

exec or nftlib version can be selected at runtime as illustrated on the
following example:

```golang
import (
        "github.com/networkplumbing/go-nft/nft"
        nftlib "github.com/networkplumbing/go-nft/nft/lib"
)

nft.ReadConfig()
nftlib.ReadConfig()
```

man page for libnftables: https://manpages.debian.org/testing/libnftables1/libnftables.3.en.html

Close: https://github.com/networkplumbing/go-nft/issues/18

Signed-off-by: Quique Llorente <ellorent@redhat.com>