### PR TITLE
schema, rule: Add anonymous`counter` statement

### DIFF
--- a/nft/schema/rule.go
+++ b/nft/schema/rule.go
@@ -35,8 +35,14 @@ type Rule struct {
 }
 
 type Statement struct {
-	Match *Match `json:"match,omitempty"`
+	Counter *Counter `json:"counter,omitempty"`
+	Match   *Match   `json:"match,omitempty"`
 	Verdict
+}
+
+type Counter struct {
+	Packets int `json:"packets"`
+	Bytes   int `json:"bytes"`
 }
 
 type Verdict struct {


### PR DESCRIPTION
Allow users to define an anonymous counter statement.

On apply, it defines the counter and/or resets the values.
On read, it presents a counter for a rule if it exists.

Resolves #26