### PR TITLE
automation, integ tests: Fix false-negative results

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -56,7 +56,7 @@ function run_container {
         -v "$PROJECT_PATH":"$CONTAINER_WORKSPACE":Z \
         -w "$CONTAINER_WORKSPACE" \
         "$CONTAINER_IMG" \
-    sh -c "$1"
+    sh -e -c "$1"
 }
 
 if [ -z "${OPT_BUILD}" ] && [ -z "${OPT_FMT}" ] && [ -z "${OPT_UTEST}" ] && [ -z "${OPT_ITEST}" ]; then


### PR DESCRIPTION
The integration tests run commands to execute two test runs: One that
unitizes the exec method and the second to utilize the lib method.

In case the first fails and the second passes, the overall result is a
pass, which is obviously wrong.

The script for running the tests has been patched to fail once an error
is detected.