### PR TITLE
automation: Run integration tests serially

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -89,8 +89,8 @@ if [ -n "${OPT_ITEST}" ]; then
     run_container '
         apk add --no-cache nftables gcc musl-dev
         nft -j list ruleset
-        go test -v --tags=exec ./tests/...
+        go test -p 1 -v --tags=exec ./tests/...
         apk add --no-cache nftables-dev
-        go test -v ./tests/nftlib
+        go test -p 1 -v ./tests/nftlib
     '
 fi


### PR DESCRIPTION
The integration tests are modifying the kernel iftables. In order to allow tests to run independently, on each test a teardown cleanup is executed. However, when tests run in parallel they will collide and the cleanup is not helpful.

This change makes sure the tests are executed serially. The parallel execution occurs due to the default parallel build of multiple packages (and their run) when using `go test`.

It may be cleaner to run each test in its own network namespace, allowing the test to run independently to how one may execute them. But this is left for follow up improvements.