### PR TITLE
tests, testlib: Assure nftables cleanup

### DIFF
--- a/tests/testlib/config.go
+++ b/tests/testlib/config.go
@@ -28,9 +28,12 @@ import (
 )
 
 func RunTestWithFlushTable(t *testing.T, test func(t *testing.T)) {
+	t.Cleanup(flushRuleset)
 	test(t)
+}
 
-	nft.ApplyConfig(&nft.Config{schema.Root{Nftables: []schema.Nftable{
+func flushRuleset() {
+	_ = nft.ApplyConfig(&nft.Config{schema.Root{Nftables: []schema.Nftable{
 		{Flush: &schema.Objects{Ruleset: true}},
 	}}})
 }


### PR DESCRIPTION
In case asserts fail or there is an unexpected panic in the tests, the cleanup (flush) of the existing nftables should still be executed.

This change assures the cleanup execution by using `defer`.