### PR TITLE
automation: Load extra kernel-modules to support CentOS Stream 9

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -86,6 +86,8 @@ if [ -n "${OPT_ITEST}" ]; then
     # Manually load `nft_masq` kmod on the host to support NAT definitions.
     # The container is unable to load a kmod (usually done by `nft` automatically).
     sudo modprobe nft_masq
+    sudo modprobe nft_counter
+    sudo modprobe nft_meta_bridge | true
     run_container '
         apk add --no-cache nftables gcc musl-dev
         nft -j list ruleset


### PR DESCRIPTION
When running the tests on CentOS Stream 9, there is a need to load two new kmods on the host that runs the tests (as the container in which the tests are running has no permission to load a kmod).

To preserve the ability to run on older hosts, the `nft_meta_bridge` kmod is not strictly required (as it is not available on older kernels).

Fixes: #47 