### PR TITLE
exec: Expose a new API that accepts a context

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.0] - 2023-**-**
+### New Features
+ - Expose API that accepts a context object for the binary exec `nft`) backend.
+   When using the top level `nft` package, the new functions are: `ReadConfigContext and `ApplyConfigContext`.
+   The old functions are kept with a default context timeout of 5 seconds.
+
+### Breaking Changes
+ - The functions exposed through `nft/exec` have been changed to accept a context.
+
 ## [0.2.0] - 2021-09-13
 ### New Features
  - Add support to link with libnftables using CGO.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ and exposes a subset of its structures.
 ```golang
 config := nft.NewConfig()
 config.AddTable(nft.NewTable("mytable", nft.FamilyIP))
-err := nft.ApplyConfig(config)
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+err := nft.ApplyConfigContext(ctx, config)
 ```
 
 - Read the configuration:
 ```golang
-config, err := nft.ReadConfig()
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+config, err := nft.ReadConfigContext(ctx)
 nftVersion := config.Nftables[0].Metainfo.Version
 ```
 

--- a/nft/config.go
+++ b/nft/config.go
@@ -20,11 +20,18 @@
 package nft
 
 import (
+	"context"
+	"time"
+
 	nftconfig "github.com/networkplumbing/go-nft/nft/config"
 	nftexec "github.com/networkplumbing/go-nft/nft/exec"
 )
 
 type Config = nftconfig.Config
+
+const (
+	defaultTimeout = 5 * time.Second
+)
 
 // NewConfig returns a new nftables config structure.
 func NewConfig() *nftconfig.Config {
@@ -35,11 +42,28 @@ func NewConfig() *nftconfig.Config {
 // returns it as a nftables config structure.
 // The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
 func ReadConfig() (*Config, error) {
-	return nftexec.ReadConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	return ReadConfigContext(ctx)
+}
+
+// ReadConfigContext loads the nftables configuration from the system and
+// returns it as a nftables config structure.
+// The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
+func ReadConfigContext(ctx context.Context) (*Config, error) {
+	return nftexec.ReadConfig(ctx)
 }
 
 // ApplyConfig applies the given nftables config on the system.
 // The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
 func ApplyConfig(c *Config) error {
-	return nftexec.ApplyConfig(c)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	return ApplyConfigContext(ctx, c)
+}
+
+// ApplyConfigContext applies the given nftables config on the system.
+// The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
+func ApplyConfigContext(ctx context.Context, c *Config) error {
+	return nftexec.ApplyConfig(ctx, c)
 }


### PR DESCRIPTION
To avoid scenarios in which the `nft` command hangs, allow clients to pass in a context to cancel/timeout the command.

Expose two new API functions that accept a context object.
- `ReadConfigContext`
- `ApplyConfigContext`

The existing `ReadConfig` and `ApplyConfig` functions are kept for
backward compatibility when used from the `nft` package.
An internal implicit timeout of 5 seconds is added for these commands.

Users who accessed the API through `nft/exec` directly are required to
update their clients (the existing functions signature has changed).

Fixes: #49 