### PR TITLE
nft: Add filter options when reading the configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,12 +2,18 @@
 
 ## [0.3.0] - 2023-**-**
 ### New Features
- - Expose API that accepts a context object for the binary exec `nft`) backend.
+ - Expose API that accepts a context object for the binary exec (`nft`) backend.
    When using the top level `nft` package, the new functions are: `ReadConfigContext and `ApplyConfigContext`.
    The old functions are kept with a default context timeout of 5 seconds.
+ - Expose API that accepts filter commands when reading the configuration.
+   When reading the configuration, by default all the ruleset are loaded.
+   Now, the caller can specify filter commands to limit the loaded entries.
+   E.g. `ReadConfig("table", "inet", "mytable")`.
 
 ### Breaking Changes
  - The functions exposed through `nft/exec` have been changed to accept a context.
+ - `ReadConfig` exposed through `nft/lib/exec` has been changed to accept filter commands.
+   The new parameter is variadic, reducing the chances a caller will be influenced by this.
 
 ## [0.2.0] - 2021-09-13
 ### New Features

--- a/nft/config.go
+++ b/nft/config.go
@@ -41,17 +41,17 @@ func NewConfig() *nftconfig.Config {
 // ReadConfig loads the nftables configuration from the system and
 // returns it as a nftables config structure.
 // The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
-func ReadConfig() (*Config, error) {
+func ReadConfig(filterCommands ...string) (*Config, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	return ReadConfigContext(ctx)
+	return ReadConfigContext(ctx, filterCommands...)
 }
 
 // ReadConfigContext loads the nftables configuration from the system and
 // returns it as a nftables config structure.
 // The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
-func ReadConfigContext(ctx context.Context) (*Config, error) {
-	return nftexec.ReadConfig(ctx)
+func ReadConfigContext(ctx context.Context, filterCommands ...string) (*Config, error) {
+	return nftexec.ReadConfig(ctx, filterCommands...)
 }
 
 // ApplyConfig applies the given nftables config on the system.

--- a/nft/exec/exec.go
+++ b/nft/exec/exec.go
@@ -42,9 +42,13 @@ const (
 // ReadConfig loads the nftables configuration from the system and
 // returns it as a nftables config structure.
 // The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
-func ReadConfig(ctx context.Context) (*nftconfig.Config, error) {
+func ReadConfig(ctx context.Context, filterCommands ...string) (*nftconfig.Config, error) {
 
-	stdout, err := execCommand(ctx, cmdJSON, cmdList, cmdRuleset)
+	whatToList := cmdRuleset
+	if len(filterCommands) > 0 {
+		whatToList = strings.Join(filterCommands, " ")
+	}
+	stdout, err := execCommand(ctx, cmdJSON, cmdList, whatToList)
 	if err != nil {
 		return nil, err
 	}

--- a/nft/lib/lib.go
+++ b/nft/lib/lib.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 /*
@@ -28,6 +29,7 @@ package lib
 import "C"
 import (
 	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/networkplumbing/go-nft/nft"
@@ -41,8 +43,12 @@ const (
 // ReadConfig loads the nftables configuration from the system and
 // returns it as a nftables config structure.
 // The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
-func ReadConfig() (*nft.Config, error) {
-	stdout, err := libNftablesRunCmd(fmt.Sprintf("%s %s", cmdList, cmdRuleset))
+func ReadConfig(filterCommands ...string) (*nft.Config, error) {
+	whatToList := cmdRuleset
+	if len(filterCommands) > 0 {
+		whatToList = strings.Join(filterCommands, " ")
+	}
+	stdout, err := libNftablesRunCmd(fmt.Sprintf("%s %s", cmdList, whatToList))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/nftlib/nftlib_test.go
+++ b/tests/nftlib/nftlib_test.go
@@ -1,3 +1,4 @@
+//go:build !exec
 // +build !exec
 
 /* This file is part of the go-nft project

--- a/tests/testlib/config.go
+++ b/tests/testlib/config.go
@@ -28,8 +28,10 @@ import (
 )
 
 func RunTestWithFlushTable(t *testing.T, test func(t *testing.T)) {
-	t.Cleanup(flushRuleset)
-	test(t)
+	t.Run("", func(t *testing.T) {
+		t.Cleanup(flushRuleset)
+		test(t)
+	})
 }
 
 func flushRuleset() {


### PR DESCRIPTION
Expose API that accepts filter commands when reading the configuration.
    
When reading the configuration, by default all the ruleset are loaded.
Now, the caller can specify filter commands to limit the loaded entries.
E.g. `ReadConfig("table", "inet", "mytable")`.

A fix to the e2e tests cleanup has been added in this PR.