### PR TITLE
nft: Increase the default-timeout to 30sec

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 ### New Features
  - Expose API that accepts a context object for the binary exec (`nft`) backend.
    When using the top level `nft` package, the new functions are: `ReadConfigContext and `ApplyConfigContext`.
-   The old functions are kept with a default context timeout of 5 seconds.
+   The old functions are kept with a default context timeout of 30 seconds.
  - Expose API that accepts filter commands when reading the configuration.
    When reading the configuration, by default all the ruleset are loaded.
    Now, the caller can specify filter commands to limit the loaded entries.

--- a/nft/config.go
+++ b/nft/config.go
@@ -30,7 +30,7 @@ import (
 type Config = nftconfig.Config
 
 const (
-	defaultTimeout = 5 * time.Second
+	defaultTimeout = 30 * time.Second
 )
 
 // NewConfig returns a new nftables config structure.


### PR DESCRIPTION
The original value of 5sec is too optimistic for some scenarios.

Picking 30sec seems a safer default, leaving up to the caller to specify a different value to fit more specific needs.