### PR TITLE
nft: Implement ApplyConfigEcho method

### DIFF
--- a/nft/config.go
+++ b/nft/config.go
@@ -67,3 +67,10 @@ func ApplyConfig(c *Config) error {
 func ApplyConfigContext(ctx context.Context, c *Config) error {
 	return nftexec.ApplyConfig(ctx, c)
 }
+
+// ApplyConfigEcho applies the given nftables config on the system, echoing
+// back the added elements with their assigned handles
+// The system is expected to have the `nft` executable deployed and nftables enabled in the kernel.
+func ApplyConfigEcho(ctx context.Context, c *Config) (*Config, error) {
+	return nftexec.ApplyConfigEcho(ctx, c)
+}

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -28,6 +28,9 @@ import (
 
 	"github.com/networkplumbing/go-nft/nft"
 	"github.com/networkplumbing/go-nft/nft/schema"
+
+	"context"
+	"time"
 )
 
 func TestConfig(t *testing.T) {
@@ -119,6 +122,15 @@ func testApplyConfigWithStatements(t *testing.T, statements ...schema.Statement)
 	assert.NoError(t, err)
 
 	config = testlib.NormalizeConfigForComparison(config)
+	newConfig = testlib.NormalizeConfigForComparison(newConfig)
+	assert.Equal(t, config.Nftables, newConfig.Nftables)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	newConfig, err = nft.ApplyConfigEcho(ctx, config)
+	assert.NoError(t, err)
+
 	newConfig = testlib.NormalizeConfigForComparison(newConfig)
 	assert.Equal(t, config.Nftables, newConfig.Nftables)
 }

--- a/tests/nftlib/nftlib_test.go
+++ b/tests/nftlib/nftlib_test.go
@@ -45,5 +45,10 @@ func TestNftlib(t *testing.T) {
 		assert.Equal(t, config.Nftables[0], newConfig.Nftables[1])
 		_, err = nftlib.ReadConfig()
 		assert.NoError(t, err)
+
+		newConfig, err = nftlib.ApplyConfigEcho(config)
+		assert.NoError(t, err)
+		assert.Len(t, newConfig.Nftables, 1, "Expecting just the empty table entry")
+		assert.Equal(t, config.Nftables, newConfig.Nftables)
 	})
 }


### PR DESCRIPTION
This is a variant of ApplyConfig which calls nft with '-e' and '-a' flags. This makes nft echo back the input after inserting handle values returned by the kernel. This way rules may be deleted later without having to list the ruleset first.

My intention with this is to use it in spoofcheck of cni-plugins to implement a list-free TearDown().